### PR TITLE
Remove trailing newlines

### DIFF
--- a/src/HeatMap.js
+++ b/src/HeatMap.js
@@ -21,7 +21,7 @@ class HeatMap extends React.Component {
 
     Object.keys(props.rawTestData).forEach((status) => {
       props.rawTestData[status].split("\n\n").forEach((testGroup) => {
-        let lines = testGroup.split("\n");
+        let lines = testGroup.replace(/\n$/, '').split("\n");
         let file = lines[0];
         let tests = lines.slice(1);
         if (!testData[file]) { testData[file] = {}; }


### PR DESCRIPTION
There's an extra test failing (`ReactMount-test.js`) in the heat map because this treats a trailing newline in the file as a another test failure.

Did not test.

I guess this is a dupe of #4